### PR TITLE
Fix substring matching on subresource key words

### DIFF
--- a/ngx_http_aws_auth_module.c
+++ b/ngx_http_aws_auth_module.c
@@ -333,19 +333,21 @@ ngx_http_aws_auth_get_canon_headers(ngx_http_request_t *r, ngx_str_t *retstr) {
 ngx_int_t
 ngx_http_arg2(ngx_http_request_t *r, u_char *name, size_t len, ngx_str_t *value) {
     u_char  *p, *last;
+    int pos = 0;
     if (r->args.len == 0) {
         return NGX_DECLINED;
     }
     p = r->args.data;
     last = p + r->args.len;
     for ( /* void */ ; p < last; p++) {
+        pos++;
         if (p + len > last) {
             return NGX_DECLINED;
         }
         if (ngx_strncasecmp(p, name, len) != 0) {
             continue;
         }
-        if (p == r->args.data || *(p - 1) == '&' || (p + len) == last || *(p + len) == '&' || *(p + len) == '=') {
+        if (p == r->args.data || ( *(p + len) == '&' && pos == 0 ) || (p + len) == last || ( *(p + len) == '=' && *(p - 1) == '&') ) {
             if ((p + len) < last && *(p + len) == '=') {
                 value->data = p + len + 1;
                 p = ngx_strlchr(p, last, '&');


### PR DESCRIPTION
- Only check whole keywords in the query parameters
- This fixes a bug where partial matches were causing incorrect
  signatures in the calls to AWS when part of a string contained
  a subresource keyword